### PR TITLE
Update install requirements to be go1.4+

### DIFF
--- a/_posts/2014-03-01-installing.md
+++ b/_posts/2014-03-01-installing.md
@@ -37,7 +37,7 @@ See [the docs][docker_docs] for deploying NSQ with [Docker][docker].
 
 #### Pre-requisites
 
- * **[golang](http://golang.org/doc/install)** (version **`1.2+`** is required)
+ * **[golang](http://golang.org/doc/install)** (version **`1.4+`** is required)
  * **[gpm](https://github.com/pote/gpm)** (dependency manager)
 
 #### Compiling


### PR DESCRIPTION
Noticed this when trying to follow the install instructions @jehiah. Instructions updated accordingly.

```
$ make install
go build  -o build/nsqd ./apps/nsqd
# github.com/nsqio/nsq/nsqd
../go/src/github.com/nsqio/nsq/nsqd/nsqd.go:46: undefined: atomic.Value
../go/src/github.com/nsqio/nsq/nsqd/nsqd.go:50: undefined: atomic.Value
../go/src/github.com/nsqio/nsq/nsqd/nsqd.go:55: undefined: atomic.Value
make: *** [build/nsqd] Error 2
```