### PR TITLE
Add elixir_nsq to list of client libraries.

### DIFF
--- a/_posts/2013-02-01-client_libraries.md
+++ b/_posts/2013-02-01-client_libraries.md
@@ -128,6 +128,19 @@ production? Tell us about it on the [mailing list][mailing_list] or Twitter [@im
     <td></td>
   </tr>
   <tr class="success">
+    <td><a href="https://github.com/wistia/elixir_nsq">elixir_nsq</a></td>
+    <td>Elixir</td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td></td>
+  </tr>
+  <tr class="success">
     <td><a href="https://github.com/project-fifo/ensq">ensq</a></td>
     <td>Erlang</td>
     <td><i class="fa fa-check"></i></td>


### PR DESCRIPTION
This should mark all support except snappy, though deflate _is_ supported.