### PR TITLE
Remove nsqphp from the list of client libraries

### DIFF
--- a/_posts/2013-02-01-client_libraries.md
+++ b/_posts/2013-02-01-client_libraries.md
@@ -180,19 +180,6 @@ production? Tell us about it on the [mailing list][mailing_list] or Twitter [@im
     <td></td>
   </tr>
   <tr class="success">
-    <td><a href="https://github.com/davegardnerisme/nsqphp">nsqphp</a></td>
-    <td>PHP</td>
-    <td><i class="fa fa-check"></i></td>
-    <td><i class="fa fa-check"></i></td>
-    <td><i class="fa fa-check"></i></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr class="success">
       <td><a href="https://github.com/dlecocq/nsq-py">nsq-py</a></td>
       <td>Python</td>
       <td><i class="fa fa-check"></i></td>


### PR DESCRIPTION
It appears that the library is not maintained anymore :(
