### PR TITLE
installing: recommend go 1.6+

### DIFF
--- a/_posts/2014-03-01-installing.md
+++ b/_posts/2014-03-01-installing.md
@@ -39,7 +39,7 @@ See [the docs][docker_docs] for deploying NSQ with [Docker][docker].
 
 #### Pre-requisites
 
- * **[golang](http://golang.org/doc/install)** (version **`1.4+`** is required)
+ * **[golang](http://golang.org/doc/install)** (version **`1.6+`** is required)
  * **[gpm](https://github.com/pote/gpm)** (dependency manager)
 
 #### Compiling


### PR DESCRIPTION
https://github.com/nsqio/nsq/pull/844 raised the requirement to go  1.5

I figured we should advertise what we actually test with, so I added back go 1.6.x in https://github.com/nsqio/nsq/pull/888