### PR TITLE
nsqjs is using now also using plain JS

### DIFF
--- a/_posts/2013-02-01-client_libraries.md
+++ b/_posts/2013-02-01-client_libraries.md
@@ -64,7 +64,7 @@ production? Tell us about it on the [mailing list][mailing_list] or Twitter [@im
   </tr>
   <tr class="success">
     <td><a href="https://github.com/dudleycarr/nsqjs">nsqjs</a></td>
-    <td>JavaScript (CoffeeScript)</td>
+    <td>JavaScript</td>
     <td><i class="fa fa-check"></i></td>
     <td><i class="fa fa-check"></i></td>
     <td><i class="fa fa-check"></i></td>


### PR DESCRIPTION
Hey,

since some days nsqjs is also using plain js. Which makes it no a major turn off anymore, at least for me. So wanted to let everyone else also see that there is a official js client now.