### PR TITLE
Update docker-compose to v3.

### DIFF
--- a/_posts/2013-12-31-docker.md
+++ b/_posts/2013-12-31-docker.md
@@ -89,7 +89,7 @@ or mount to a host-directory:
 
 To start `nsqd`, `nsqlookupd`, and `nsqadmin` together using `docker-compose` then create a `docker-compose.yml`.
 
-    version: '2'
+    version: '3'
     services:
       nsqlookupd:
         image: nsqio/nsq
@@ -100,12 +100,16 @@ To start `nsqd`, `nsqlookupd`, and `nsqadmin` together using `docker-compose` th
       nsqd:
         image: nsqio/nsq
         command: /nsqd --lookupd-tcp-address=nsqlookupd:4160
+        depends_on:
+          - nsqlookupd
         ports:
           - "4150"
           - "4151"
       nsqadmin:
         image: nsqio/nsq
         command: /nsqadmin --lookupd-http-address=nsqlookupd:4161
+        depends_on:
+          - nsqlookupd  
         ports:
           - "4171"
 


### PR DESCRIPTION
Hi,

I updated the docker-compose file to v3. Luckily, it doesn't require any changes.
Additionally, I added `depends_on` statements, since `nsqadmin` fails when `nsqlookupd` is not present yet.