### PR TITLE
switch highlighter from "pigments" to "rouge"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 source: .
 version: 1.0.0-compat
-highlighter: pygments
+highlighter: rouge
 baseurl: ''
 markdown: kramdown


### PR DESCRIPTION
to avoid github site-gen warning email

This is the email I received from GitHub the last time I merged a PR in this repo:

> The page build completed successfully, but returned the following warning for the `master` branch:

> You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset.