### PR TITLE
nsqd: add topic message_bytes metric

### DIFF
--- a/_posts/2012-12-01-nsqd.md
+++ b/_posts/2012-12-01-nsqd.md
@@ -521,6 +521,7 @@ The `nsqd` instance will push to the following `statsd` paths:
     nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.backend_depth [gauge]
     nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.depth [gauge]
     nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.message_count
+    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.message_bytes
     nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.backend_depth [gauge]
     nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.clients [gauge]
     nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.deferred_count [gauge]


### PR DESCRIPTION
This PR will  add the `message_size` topic metric to the doc. 

Note: this is a following PR for adding `message_size` metric in https://github.com/nsqio/nsq/pull/1127