### PR TITLE
update benchcmp and graphite links, remove Godeps link

### DIFF
--- a/_posts/2011-12-15-nsq_internals.md
+++ b/_posts/2011-12-15-nsq_internals.md
@@ -266,10 +266,8 @@ There are two main schools of thought:
 **Note:** This really only applies to *binary* packages as it doesn't make sense for an importable
 package to make intermediate decisions as to which version of a dependency to use.
 
-NSQ uses **[gpm][gpm]** to provide support for (2) above.
-
-It works by recording your dependencies in a [`Godeps`][godeps] file, which we later use to
-construct a `GOPATH` environment.
+NSQ uses method (2) above. (It first used [gpm][gpm], then [dep][dep], and now
+uses [Go modules][modules]).
 
 ## Testing
 
@@ -437,6 +435,8 @@ occurs rather than trying to reduce chattiness at the expense of usefulness.
 [design_doc]: https://nsq.io/overview/design.html
 [protocol_spec]: https://nsq.io/clients/tcp_protocol_spec.html
 [gpm]: https://github.com/pote/gpm
+[dep]: https://github.com/golang/dep
+[modules]: https://github.com/golang/go/wiki/Modules
 [hol_blocking]: https://en.wikipedia.org/wiki/Head-of-line_blocking
 [encoding_binary]: https://golang.org/pkg/encoding/binary/
 [byte_order]: https://golang.org/pkg/encoding/binary/#ByteOrder
@@ -453,13 +453,12 @@ occurs rather than trying to reduce chattiness at the expense of usefulness.
 [statsd]: https://github.com/etsy/statsd/
 [sync_pool]: https://groups.google.com/forum/#!topic/golang-dev/kJ_R6vYVYHU
 [testing]: https://golang.org/pkg/testing/
-[benchcmp]: https://golang.org/misc/benchcmp
+[benchcmp]: https://godoc.org/golang.org/x/tools/cmd/benchcmp
 [issue_3512]: https://code.google.com/p/go/issues/detail?id=3512
 [issue_4720]: https://code.google.com/p/go/issues/detail?id=4720
 [issue_5376]: https://code.google.com/p/go/issues/detail?id=5376
-[godeps]: https://github.com/nsqio/nsq/blob/master/Godeps
 [runtime_time]: https://golang.org/src/pkg/runtime/time.go?s=1684:1787#L83
 [autobench]: https://github.com/davecheney/autobench
 [escape_an]: https://en.wikipedia.org/wiki/Escape_analysis
-[base10_convert]: https://github.com/nsqio/nsq/blob/master/internal/protocol/byte_base10.go#L9-L29
+[base10_convert]: https://github.com/nsqio/nsq/blob/v1.2.0/internal/protocol/byte_base10.go#L9-L29
 [topology_patterns]: https://nsq.io/deployment/topology_patterns.html

--- a/_posts/2011-12-15-nsq_internals.md
+++ b/_posts/2011-12-15-nsq_internals.md
@@ -74,7 +74,7 @@ Go runtime's *global* timer scheduler.
 This supports (but is not limited to) the entirety of the `time` package. It normally obviates the
 need for a *user-land* time-ordered priority queue but it's important to keep in mind that it's a
 *single* data structure with a *single* lock, potentially impacting `GOMAXPROCS > 1` performance.
-See [runtime/time.go][runtime_time].
+See [runtime/time.go][runtime_time]. (No longer true in go-1.10+)
 
 ## Backend / DiskQueue
 
@@ -457,7 +457,7 @@ occurs rather than trying to reduce chattiness at the expense of usefulness.
 [issue_3512]: https://code.google.com/p/go/issues/detail?id=3512
 [issue_4720]: https://code.google.com/p/go/issues/detail?id=4720
 [issue_5376]: https://code.google.com/p/go/issues/detail?id=5376
-[runtime_time]: https://golang.org/src/pkg/runtime/time.go?s=1684:1787#L83
+[runtime_time]: https://github.com/golang/go/blob/release-branch.go1.9/src/runtime/time.go#L92
 [autobench]: https://github.com/davecheney/autobench
 [escape_an]: https://en.wikipedia.org/wiki/Escape_analysis
 [base10_convert]: https://github.com/nsqio/nsq/blob/v1.2.0/internal/protocol/byte_base10.go#L9-L29

--- a/_posts/2012-02-01-features_and_guarantees.md
+++ b/_posts/2012-02-01-features_and_guarantees.md
@@ -76,4 +76,4 @@ By being transparent about the reality of these tradeoffs we hope to set expecta
 [nsqlookupd]: https://github.com/nsqio/nsq/tree/master/nsqlookupd/README.md
 [nsqadmin]: https://github.com/nsqio/nsq/tree/master/nsqadmin/README.md
 [statsd]: https://github.com/etsy/statsd/
-[graphite]: https://graphite.wikidot.com/
+[graphite]: https://graphiteapp.org/

--- a/_posts/2014-02-01-production.md
+++ b/_posts/2014-02-01-production.md
@@ -63,5 +63,5 @@ For realtime debugging this also works surprisingly well:
 Typically most debugging, analysis, and administration is done via `nsqadmin`.
 
 [statsd]: https://github.com/bitly/statsdaemon
-[graphite]: https://graphite.wikidot.com/
+[graphite]: https://graphiteapp.org/
 [nsqd_statsd]: {{ site.baseurl }}/components/nsqd.html#statsd


### PR DESCRIPTION
also update mention of gpm with links to dep and go modules
also make byte_base10 link to a specific tag in case master changes

also, the runtime timers lock is no longer a single global lock, in go-1.10 it was split into 64 shards:
https://github.com/golang/go/blob/release-branch.go1.10/src/runtime/time.go#L32-L54
... anyway I tried to keep a light touch, since this is sort of a historical blog post.

cc @jehiah @mreiferson 