### PR TITLE
Add link to tokio-nsq rust client library

### DIFF
--- a/_posts/2013-02-01-client_libraries.md
+++ b/_posts/2013-02-01-client_libraries.md
@@ -1,4 +1,4 @@
---- 
+---
 title: Client Libraries
 layout: post
 category: Clients
@@ -502,6 +502,19 @@ production? Tell us about it on the [mailing list][mailing_list] or Twitter [@im
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+  </tr>
+  <tr class="warning">
+    <td><a href="https://github.com/harporoeder/tokio-nsq">tokio-nsq</a></td>
+    <td>Rust</td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
     <td></td>
   </tr>
 </table>


### PR DESCRIPTION
Adds a link to the `tokio-nsq` rust client library.

I notice that there are three sections of various colors. I am unsure how these are classified so I placed it on the bottom with the `warning` class.