### PR TITLE
remove reference to nsq_pubsub

### DIFF
--- a/_posts/2012-01-01-design.md
+++ b/_posts/2012-01-01-design.md
@@ -88,7 +88,6 @@ side by limiting the code changes to bootstrapping.  All business logic remained
 Finally, we built utilities to glue old and new components together. These are all available in the
 `examples` directory in the repository:
 
- * `nsq_pubsub` - expose a `pubsub` like HTTP interface to topics in an **NSQ** cluster
  * `nsq_to_file` - durably write all messages for a given topic to a file
  * `nsq_to_http` - perform HTTP requests for all messages in a topic to (multiple) endpoints
 


### PR DESCRIPTION
Hi. I believe docs about `nsq_pubsub` are outdated as I can't find to find `nsq_pubsub` in `apps` and other docs