### PR TITLE
fix TCP Protocol Spec navigation

### DIFF
--- a/_posts/2013-03-01-tcp_protocol_spec.md
+++ b/_posts/2013-03-01-tcp_protocol_spec.md
@@ -1,7 +1,7 @@
 ---
 title: TCP Protocol Spec
 layout: post
-category: clients
+category: Clients
 permalink: /clients/tcp_protocol_spec.html
 ---
 


### PR DESCRIPTION
This fixes a bug where the "TCP Protocol Spec" didn't correctly show under "Clients" along with "Client Libraries" and "Building Client Libraries"

![Screen Shot 2020-11-23 at 10 24 59 AM](https://user-images.githubusercontent.com/45028/99980476-4a3f8600-2d76-11eb-8cb7-ac869c056312.png)
