### PR TITLE
Fix command path error in design.md

### DIFF
--- a/_posts/2012-01-01-design.md
+++ b/_posts/2012-01-01-design.md
@@ -77,7 +77,7 @@ all built upon our existing messaging tools, so we needed a way to slowly and me
 specific parts of our infrastructure with little to no impact.
 
 First, on the message *producer* side we built `nsqd` to match [simplequeue][simplequeue].
-Specifically, nsqd exposes an HTTP `/put` endpoint, just like `simplequeue`, to POST binary data
+Specifically, nsqd exposes an HTTP `/pub` endpoint, just like `simplequeue`, to POST binary data
 (with the one caveat that the endpoint takes an additional query parameter specifying the "topic").
 Services that wanted to switch to start publishing to `nsqd` only have to make minor code changes.
 


### PR DESCRIPTION
As per https://github.com/nsqio/nsq/blob/master/nsqd/http.go#L60 the "put" command is actually "pub" instead.