### PR TITLE
Correction of topic/channel name length requirements

### DIFF
--- a/_posts/2013-01-01-tcp_protocol_spec.md
+++ b/_posts/2013-01-01-tcp_protocol_spec.md
@@ -37,7 +37,7 @@ behavior.
  * Unless stated otherwise, **all** binary sizes/integers on the wire are **network byte order**
   (ie. *big* endian)
 
- * Valid *topic* and *channel* names are characters `[.a-zA-Z0-9_-]` and `1 < length <= 64` 
+ * Valid *topic* and *channel* names are characters `[.a-zA-Z0-9_-]` and `1 <= length <= 64` 
   (max length was `32` prior to `nsqd` `0.2.28`)
 
 ### Commands


### PR DESCRIPTION
There seems to be an inconsistency between the documentation and the real requirements when it comes to the length of topic or channel names. The documentation states a minimum length of `2`, whereas technically a length of just `1` is sufficient and actually works fine (and as far as I can see, always did in previous versions as well). This pull request updates the documentation to the correct length boundaries.