### PR TITLE
Clarify REQ 'timeout' field in TCP spec

### DIFF
--- a/_posts/2013-01-01-tcp_protocol_spec.md
+++ b/_posts/2013-01-01-tcp_protocol_spec.md
@@ -288,7 +288,8 @@ Similarly, a message that is in-flight and times out behaves identically to an e
 
     <message_id> - message id as 16-byte hex string
     <timeout> - a string representation of integer N where N <= configured max timeout
-        0 is a special case that will not defer re-queueing
+        timeout == 0 - requeue a message immediately
+        timeout  > 0 - defer requeue for timeout milliseconds
 
 NOTE: there is no success response
 


### PR DESCRIPTION
We were a bit confused about what the behavior of the 'timeout' parameter was for the TCP REQ command. We ended up having to dig into the [source code](https://github.com/nsqio/nsq/blob/master/nsqd/channel.go#L368) to understand what was happening, and thought we'd just update the docs with what we found in the code.

NOTE: I wasn't able to try rendering the docs site locally, since I couldn't get the nokogiri gem to compile on Apple silicon, but here's a markdown preview in VS code:

![Screen Shot 2022-12-05 at 9 11 38 AM](https://user-images.githubusercontent.com/44368/205672249-381f903c-0376-481a-8724-e435a2716213.png)

Thanks for NSQ!