### PR TITLE
Bump config version to 1.3.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 source: .
-version: 1.2.1
+version: 1.3.0
 highlighter: rouge
 baseurl: ''
 markdown: kramdown


### PR DESCRIPTION
nsq.io is showing `1.2.1` as the latest version in the header. Fix by bumping the version in `_config.yml`.