### PR TITLE
chore(nsqd): added documentation for  max-defer-timeout

### DIFF
--- a/_posts/2012-12-01-nsqd.md
+++ b/_posts/2012-12-01-nsqd.md
@@ -71,6 +71,8 @@ can optionally listen on a third port for HTTPS.
         maximum RDY count for a client (default 2500)
     -max-req-timeout duration
         maximum requeuing timeout for a message (default 1h0m0s)
+    -max-defer-timeout duration
+        maximum defer duration for deferred publish (default 1h0m0s, falls back to --max-req-timeout if not set)
     -mem-queue-size int
         number of messages to keep in memory (per topic/channel) (default 10000)
     -min-output-buffer-timeout duration
@@ -157,7 +159,7 @@ can optionally listen on a third port for HTTPS.
   Query Params:
 
       topic - the topic to publish to
-      defer - the time in ms to delay message delivery (optional)
+      defer - the time in ms to delay message delivery (optional, up to max-defer-timeout)
 
   Body:
 
@@ -175,6 +177,7 @@ can optionally listen on a third port for HTTPS.
 
       topic - the topic to publish to
       binary - bool ('true' or 'false') to enable binary mode
+      defer - the time in ms to delay message delivery for all messages (optional, up to max-defer-timeout)
 
   Body
 
@@ -572,3 +575,7 @@ The `nsqd` instance will push to the following `statsd` paths:
 [bquant]: https://www.cs.rutgers.edu/~muthu/bquant.pdf
 [bmizerany]: https://github.com/bmizerany
 [perks]: https://github.com/bmizerany/perks
+
+### Deferred Publish Timeout
+
+The maximum allowed defer time for publishing messages (using the `defer` parameter in `/pub` or `/mpub`) is now controlled by the `--max-defer-timeout` option (default: 1h). If `--max-defer-timeout` is not set, it falls back to the value of `--max-req-timeout` for backward compatibility.


### PR DESCRIPTION
## Background
Previously, NSQD's deferred publish timeout was implicitly governed by the `max-req-timeout` configuration. With the introduction of a dedicated `max-defer-timeout` option in NSQD, the documentation needs to reflect this new behavior and configuration.

## Changes Done
1. added documentation for the new `max-defer-timeout` command line option, including its default value and fallback behavior.
2. updated the `/pub` and `/mpub` HTTP API documentation to clarify that the `defer` parameter is now governed by `max-defer-timeout`.
3. added a section explaining the deferred publish timeout and its backward compatibility with `max-req-timeout`.

## Related PR
- [NSQ PR #1504](https://github.com/nsqio/nsq/pull/1504)

## TODO
- [ ] merge after corresponding NSQD release